### PR TITLE
Dependencies on intrastat

### DIFF
--- a/delivery_carrier_colipostefr/__openerp__.py
+++ b/delivery_carrier_colipostefr/__openerp__.py
@@ -34,6 +34,7 @@
         'document',
         'file_repository',
         'delivery_carrier_deposit',
+        'intrastat_base',
     ],
     'description': """
 Delivery Carrier ColiPoste

--- a/delivery_carrier_label_colissimo/__openerp__.py
+++ b/delivery_carrier_label_colissimo/__openerp__.py
@@ -29,7 +29,7 @@
     'depends': [
         'delivery_carrier_colipostefr',
         'delivery_carrier_deposit',
-        'l10n_fr_intrastat_product',
+        'intrastat_product',
     ],
     'description': """
 Delivery Carrier Label Colissimo


### PR DESCRIPTION
As far as I can see, the dependency on l10n_fr_intrastat_product is not longer necessary in delivery_carrier_label_colissimo.
A dependency on intrastat is required in delivery_carrier_colipostefr, but intrastat_base is sufficient.

It could be planned to change in the future or I may have missed something, in either case, please discard this PR.
