### PR TITLE
Argument missing in orm.except_orm

### DIFF
--- a/delivery_carrier_colipostefr/deposit_slip.py
+++ b/delivery_carrier_colipostefr/deposit_slip.py
@@ -130,6 +130,7 @@ class DepositSlip(orm.Model):
                     cr, uid, address.email, context=context)
                 if not phone and not mobile and not email:
                     raise orm.except_orm(
+                        _('Error'),
                         _(u"Information manquante sur le bon de "
                           u"livraison %s : il faut renseigner au moins "
                           u"le téléphone, le portable ou l'e-mail sur "


### PR DESCRIPTION
Resulting in:
TypeError: **init**() takes exactly 3 arguments (2 given)
